### PR TITLE
KEYMAPPER: Code format correction.

### DIFF
--- a/backends/keymapper/keymap.h
+++ b/backends/keymapper/keymap.h
@@ -45,7 +45,7 @@ class HardwareInputSet;
 class KeymapperDefaultBindings;
 
 struct HardwareInput_EqualTo {
-	bool operator()(const HardwareInput& x, const HardwareInput& y) const {
+	bool operator()(const HardwareInput &x, const HardwareInput &y) const {
 		return (x.type == y.type)
 		        && (x.key.keycode == y.key.keycode)
 		        && (x.key.flags == y.key.flags)
@@ -54,7 +54,7 @@ struct HardwareInput_EqualTo {
 };
 
 struct HardwareInput_Hash {
-	uint operator()(const HardwareInput& x) const {
+	uint operator()(const HardwareInput &x) const {
 		uint hash = 7;
 		hash = 31 * hash + x.type;
 		hash = 31 * hash + x.key.keycode;


### PR DESCRIPTION
Correcting the code format according to the guidelines.
- Line 48 `(const HardwareInput& x, const HardwareInput& y)` is replaced by `(const HardwareInput &x, const HardwareInput &y)`.
- Line 57 `(const HardwareInput& x)` is replaced by `(const HardwareInput &x)`.